### PR TITLE
Restore Windows 2003 compatibility

### DIFF
--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -33,6 +33,8 @@ module Windows
     attach_pfunc :WaitForSingleObject, [:handle, :dword], :dword, :blocking => true
     attach_pfunc :WaitForMultipleObjects, [:dword, :ptr, :bool, :dword], :dword
 
+    attach_pfunc :GetVersionExW, [:ptr], :bool
+
     ffi_lib :advapi32
 
     callback :handler_ex, [:ulong, :ulong, :ptr, :ptr], :void

--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -4,7 +4,10 @@ module Windows
   module Structs
     extend FFI::Library
 
+    typedef :uchar, :byte
+    typedef :uint16, :word
     typedef :ulong, :dword
+
 
     class SERVICE_STATUS < FFI::Struct
       layout(
@@ -115,6 +118,22 @@ module Windows
       layout(
         :PrivilegeCount, :dword,
         :Privileges, [LUID_AND_ATTRIBUTES, 1]
+      )
+    end
+
+    class OSVERSIONINFO < FFI::Struct
+      layout(
+        :dwOSVersionInfoSize, :dword,
+        :dwMajorVersion, :dword,
+        :dwMinorVersion, :dword,
+        :dwBuildNumber, :dword,
+        :dwPlatformId, :dword,
+        :szCSDVersion, [:uint16, 128],
+        :wServicePackMajor, :word,
+        :wServicePackMinor, :word,
+        :wSuiteMask, :word,
+        :wProductType, :byte,
+        :wReserved, :byte,
       )
     end
   end

--- a/test/test_win32_daemon.rb
+++ b/test/test_win32_daemon.rb
@@ -17,7 +17,7 @@ class TC_Daemon < Test::Unit::TestCase
   end
 
   test "version number is set properly" do
-    assert_equal('0.8.4', Daemon::VERSION)
+    assert_equal('0.8.6', Daemon::VERSION)
   end
 
   test "constructor basic functionality" do

--- a/test/test_win32_service.rb
+++ b/test/test_win32_service.rb
@@ -52,7 +52,7 @@ class TC_Win32_Service < Test::Unit::TestCase
   end
 
   test "version number is expected value" do
-    assert_equal('0.8.5', Win32::Service::VERSION)
+    assert_equal('0.8.6', Win32::Service::VERSION)
   end
 
   test "services basic functionality" do

--- a/test/test_win32_service.rb
+++ b/test/test_win32_service.rb
@@ -11,13 +11,13 @@ require 'socket'
 class TC_Win32_Service < Test::Unit::TestCase
   def self.startup
     @@host = Socket.gethostname
-    @@service_name = 'stisvc'
+    @@service_name = 'LanmanServer'
     @@elevated = Win32::Security.elevated_security?
   end
 
   def setup
-    @display_name = 'Windows Image Acquisition (WIA)'
-    @service_name = 'stisvc'
+    @display_name = 'Server'
+    @service_name = 'LanmanServer'
     @service_stat = nil
     @services     = []
 

--- a/test/test_win32_service_configure.rb
+++ b/test/test_win32_service_configure.rb
@@ -64,9 +64,19 @@ class TC_Win32_Service_Configure < Test::Unit::TestCase
     assert_equal('disabled', config_info.start_type)
   end
 
-  test "service start can be delayed" do
+  test "service start can be delayed on Windows versions newer than 2003" do
+    omit_if(Win32::Service.windows_version < 6)
     service_configure(:start_type => Win32::Service::AUTO_START, :delayed_start => true)
     assert_true(full_info.delayed_start)
+  end
+
+  test "service start cannot be delayed on Windows versions older than 2003" do
+    omit_if(Win32::Service.windows_version >= 6)
+    assert_raise(ArgumentError){
+      Win32::Service.configure(
+      :service_name => @@service,
+      :start_type => Win32::Service::AUTO_START, :delayed_start => true)
+    }
   end
 
   test "the configure method requires one argument" do


### PR DESCRIPTION
 - In commit f651812, support for a `delayed_start` option was added
   so that `ChangeServiceConfig2` could be used to configure a service
   with a delayed start.  That information can also be retrieved via
   `QueryServiceConfig2` and the `SERVICE_DELAYED_AUTO_START_INFO` struct.

   However, this constant does not exist prior to Vista / Windows 2008,
   and thus this code outright fails on Windows 2003.

   https://msdn.microsoft.com/en-us/library/windows/desktop/ms684935%28v=vs.85%29.aspx

   Add a call to Windows `GetVersionEx` to retrieve the Windows version,
   and guard against retrieving this additional information on
   platforms where it is not supported.  Further, generate an error
   when trying to set delayed_start in the call to configure on
   unsupported platforms.

   Since the current tests are written in test-unit, and there's no way
   to mock the Windows version call, instead guard the tests on the
   platform they're executing on.