### PR TITLE
Updated SERVICE_DELAYED_AUTO_START_INFO

### DIFF
--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -37,7 +37,15 @@ module Windows
     end
 
     class SERVICE_DELAYED_AUTO_START_INFO < FFI::Struct
-      layout(:fDelayedAutostart, :bool)
+      layout(:fDelayedAutostart, :int) # BOOL
+      alias aset []=
+
+      # Intercept the accessor so that we can handle either true/false or 1/0.
+      # Since there is only one member, there's no need to check the key name.
+      #
+      def []=(key, value)
+        value ? aset(key, 1) : aset(key, 0)
+      end
     end
 
     class QUERY_SERVICE_CONFIG < FFI::Struct


### PR DESCRIPTION
I restored the data type from :bool to :int because it's a different byte size, which caused problems as described in https://github.com/djberg96/win32-service/issues/27. I modified the struct member accessor to accept either true/false or 1/0. This should provide maximum flexibility as well as backwards compatibility.