### PR TITLE
Fix function prototypes, namespace functions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+version: '{build}'
+branches:
+  only:
+  - ffi
+skip_tags: true
+clone_depth: 10
+environment:
+  matrix:
+  - ruby_version: 193
+    ruby_dir: 1.9.1
+  - ruby_version: 200
+    ruby_dir: 2.0.0
+  - ruby_version: 200-x64
+    ruby_dir: 2.0.0
+  - ruby_version: 21
+    ruby_dir: 2.1.0
+  - ruby_version: 21-x64
+    ruby_dir: 2.1.0
+  - ruby_version: 22
+    ruby_dir: 2.2.0
+  - ruby_version: 22-x64
+    ruby_dir: 2.2.0
+install:
+- ps: >-
+    $env:path = "C:\Ruby" + $env:ruby_version + "\bin;" + $env:path
+
+    $tpath = "C:\Ruby" + $env:ruby_version + "\lib\ruby\" + $env:ruby_dir + "\test"
+
+    if ((test-path $tpath) -eq $True){ rm -recurse -force $tpath }
+
+    gem update --system > $null
+
+    if ((gem query -i ffi) -eq $False){ gem install ffi --no-document }
+
+    if ((gem query -i win32-security) -eq $False){ gem install win32-security --no-document }
+
+    if ((gem query -i test-unit -v ">= 3.0") -eq $False){ gem install test-unit --no-document }
+cache:
+- C:\Ruby193\lib\ruby\gems\1.9.1
+- C:\Ruby200\lib\ruby\gems\2.0.0
+- C:\Ruby200-x64\lib\ruby\gems\2.0.0
+- C:\Ruby21\lib\ruby\gems\2.1.0
+- C:\Ruby21-x64\lib\ruby\gems\2.1.0
+- C:\Ruby22\lib\ruby\gems\2.2.0
+- C:\Ruby22-x64\lib\ruby\gems\2.2.0
+build: off
+test_script:
+- cmd: rake

--- a/lib/win32/daemon.rb
+++ b/lib/win32/daemon.rb
@@ -1,9 +1,7 @@
-require File.join(File.dirname(__FILE__), 'windows', 'helper')
-require File.join(File.dirname(__FILE__), 'windows', 'constants')
-require File.join(File.dirname(__FILE__), 'windows', 'structs')
-require File.join(File.dirname(__FILE__), 'windows', 'functions')
-
-require 'ffi'
+require_relative 'windows/helper'
+require_relative 'windows/constants'
+require_relative 'windows/structs'
+require_relative 'windows/functions'
 
 # The Win32 module serves as a namespace only.
 module Win32
@@ -11,14 +9,14 @@ module Win32
   # The Daemon class
   class Daemon
     include Windows::ServiceConstants
-    include Windows::Structs
-    include Windows::Functions
+    include Windows::ServiceStructs
+    include Windows::ServiceFunctions
 
-    extend Windows::Structs
-    extend Windows::Functions
+    extend Windows::ServiceStructs
+    extend Windows::ServiceFunctions
 
     # The version of this library
-    VERSION = '0.8.6'
+    VERSION = '0.8.8'
 
     private
 
@@ -240,21 +238,21 @@ module Win32
       service_init() if respond_to?('service_init')
 
       # Create the event to signal the service to start.
-      @@hStartEvent = CreateEvent(nil, true, false, nil)
+      @@hStartEvent = CreateEvent(nil, 1, 0, nil)
 
       if @@hStartEvent == 0
         raise SystemCallError.new('CreateEvent', FFI.errno)
       end
 
       # Create the event to signal the service to stop.
-      @@hStopEvent = CreateEvent(nil, true, false, nil)
+      @@hStopEvent = CreateEvent(nil, 1, 0, nil)
 
       if @@hStopEvent == 0
         raise SystemCallError.new('CreateEvent', FFI.errno)
       end
 
       # Create the event to signal the service that stop has completed
-      @@hStopCompletedEvent = CreateEvent(nil, true, false, nil)
+      @@hStopCompletedEvent = CreateEvent(nil, 1, 0, nil)
 
       if @@hStopCompletedEvent == 0
         raise SystemCallError.new('CreateEvent', FFI.errno)

--- a/lib/win32/service.rb
+++ b/lib/win32/service.rb
@@ -10,14 +10,14 @@ module Win32
   # creating, starting, configuring or deleting services.
   class Service
     include Windows::ServiceConstants
-    include Windows::Structs
-    include Windows::Functions
+    include Windows::ServiceStructs
+    include Windows::ServiceFunctions
 
-    extend Windows::Structs
-    extend Windows::Functions
+    extend Windows::ServiceStructs
+    extend Windows::ServiceFunctions
 
     # The version of the win32-service library
-    VERSION = '0.8.7'
+    VERSION = '0.8.8'
 
     # SCM security and access rights
 
@@ -1242,7 +1242,7 @@ module Win32
         # Enable shutdown privilege in access token of this process
         bool = AdjustTokenPrivileges(
           token_handle,
-          false,
+          0,
           tkp,
           tkp.size,
           nil,

--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -1,7 +1,7 @@
 require 'ffi'
 
 module Windows
-  module Functions
+  module ServiceFunctions
     extend FFI::Library
 
     # Make FFI functions private
@@ -22,7 +22,7 @@ module Windows
     ffi_lib :kernel32
 
     attach_pfunc :CloseHandle, [:handle], :bool
-    attach_pfunc :CreateEvent, :CreateEventA, [:ptr, :bool, :bool, :str], :handle
+    attach_pfunc :CreateEvent, :CreateEventA, [:ptr, :int, :int, :str], :handle
     attach_pfunc :CreateThread, [:ptr, :size_t, :ptr, :ptr, :dword, :ptr], :handle, :blocking => true
     attach_pfunc :EnterCriticalSection, [:ptr], :void
     attach_pfunc :FormatMessage, :FormatMessageA, [:ulong, :ptr, :ulong, :ulong, :str, :ulong, :ptr], :ulong
@@ -31,13 +31,13 @@ module Windows
     attach_pfunc :LeaveCriticalSection, [:ptr], :void
     attach_pfunc :SetEvent, [:handle], :bool
     attach_pfunc :WaitForSingleObject, [:handle, :dword], :dword, :blocking => true
-    attach_pfunc :WaitForMultipleObjects, [:dword, :ptr, :bool, :dword], :dword
+    attach_pfunc :WaitForMultipleObjects, [:dword, :ptr, :int, :dword], :dword
 
     ffi_lib :advapi32
 
     callback :handler_ex, [:ulong, :ulong, :ptr, :ptr], :void
 
-    attach_pfunc :AdjustTokenPrivileges, [:handle, :bool, :ptr, :dword, :ptr, :ptr], :bool
+    attach_pfunc :AdjustTokenPrivileges, [:handle, :int, :ptr, :dword, :ptr, :ptr], :bool
     attach_pfunc :CloseServiceHandle, [:handle], :bool
 
     attach_pfunc :ChangeServiceConfig, :ChangeServiceConfigA,

--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -1,7 +1,7 @@
 require 'ffi'
 
 module Windows
-  module Structs
+  module ServiceStructs
     extend FFI::Library
 
     typedef :ulong, :dword

--- a/win32-service.gemspec
+++ b/win32-service.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'win32-service'
-  spec.version    = '0.8.7'
+  spec.version    = '0.8.8'
   spec.authors    = ['Daniel J. Berger', 'Park Heesob']
   spec.license    = 'Artistic 2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('ffi')
   spec.add_development_dependency('test-unit')
   spec.add_development_dependency('rake')
+  spec.add_development_dependency('win32-security')
 
   spec.description = <<-EOF
     The win32-service library provides a Ruby interface to services on


### PR DESCRIPTION
What started off as a single issue ended up ballooning a bit, so I created a PR instead of pushing directly.

First and foremost, this updates the CreateEvent and AdjustTokenPrivileges function prototypes. Originally I had :bool arguments. As was pointed out to me on other gems, :bool and :int are not really interchangeable because they reserve a different amount of memory. While this is primarily an issue for structs, it should be set properly for functions as well, at least for arguments (i.e. return types are fine as :bool).

While I was at it, I also decided to use relative_require instead of manually doing require's.

I also updated the module names so that they're appropriately namespaced, e.g. `ServiceFunctions` instead of just `Functions`. I did this for constants already, so I'm not sure why I didn't do it for the other modules. Anyway, it solves https://github.com/djberg96/win32-eventlog/issues/20.

I also added win32-security as a dev dependency so that certain tests would be skipped unless run with elevated privileges. Some rules changed after Windows 7 that made tests fail if not run with elevated privileges. Since creating and configuring services is a bit invasive, I altered those tests to only run in privileged mode.

Last but not least I added an appveyor.yml file.