### PR TITLE
Resolving Failure Config Info Bug

### DIFF
--- a/lib/win32/service.rb
+++ b/lib/win32/service.rb
@@ -1143,7 +1143,7 @@ module Win32
                   actions = {}
 
                   num_actions.times{ |n|
-                    sc_action = SC_ACTION.new(action_ptr[n])
+                    sc_action = SC_ACTION.new(action_ptr[n * SC_ACTION.size])
                     delay = sc_action[:Delay]
                     action_type = get_action_type(sc_action[:Type])
                     actions[n+1] = {:action_type => action_type, :delay => delay}


### PR DESCRIPTION
This resolves a problem where, while reading failure config information, recovery options would be incorrectly reported. The cause of the bug was iterating over a pointer by a byte, not by the actual size of the struct.