### PR TITLE
Allow daemon to accept SERVICE_CONTROL_PARAMCHANGE control code

### DIFF
--- a/lib/win32/daemon.rb
+++ b/lib/win32/daemon.rb
@@ -81,7 +81,7 @@ module Win32
       else
         ss[:dwControlsAccepted] =
         SERVICE_ACCEPT_STOP|SERVICE_ACCEPT_SHUTDOWN|
-        SERVICE_ACCEPT_PAUSE_CONTINUE|SERVICE_ACCEPT_SHUTDOWN
+        SERVICE_ACCEPT_PAUSE_CONTINUE|SERVICE_ACCEPT_PARAMCHANGE
       end
 
       # Initialize ss structure.


### PR DESCRIPTION
Looks like the ``SERVICE_ACCEPT_SHUTDOWN`` flag was included twice in the list of accepted controls.  Replaced the second instance with ``SERVICE_ACCEPT_PARAMCHANGE`` so the daemon can handle the paramchange control.